### PR TITLE
[54] Deleting events from the remote endpoint

### DIFF
--- a/data/src/main/java/me/androidbox/data/di/RespositoryModule.kt
+++ b/data/src/main/java/me/androidbox/data/di/RespositoryModule.kt
@@ -20,6 +20,7 @@ import me.androidbox.data.local.dao.TaskDao
 import me.androidbox.data.local.database.BusbyTaskyDatabase
 import me.androidbox.data.local.event.EventRepositoryImp
 import me.androidbox.data.remote.agenda.AgendaRemoteRepositoryImp
+import me.androidbox.data.remote.event.DeleteEventWithIdRemoteUseCaseImp
 import me.androidbox.data.remote.event.VerifyVisitorEmailUseCaseImp
 import me.androidbox.data.remote.preference.PreferenceRepositoryImp
 import me.androidbox.data.worker_manager.AgendaSynchronizerImp
@@ -28,6 +29,7 @@ import me.androidbox.data.worker_manager.UploadEventImp
 import me.androidbox.domain.authentication.preference.PreferenceRepository
 import me.androidbox.domain.authentication.remote.AgendaLocalRepository
 import me.androidbox.domain.authentication.remote.EventRepository
+import me.androidbox.domain.event.usecase.DeleteEventWithIdRemoteUseCase
 import me.androidbox.domain.event.usecase.VerifyVisitorEmailUseCase
 import me.androidbox.domain.repository.AgendaRemoteRepository
 import me.androidbox.domain.work_manager.AgendaSynchronizer
@@ -62,6 +64,10 @@ interface RepositoryModule {
     @Reusable
     @Binds
     fun bindsAgendaRepositoryImp(agendaLocalRepositoryImp: AgendaLocalRepositoryImp): AgendaLocalRepository
+
+    @Reusable
+    @Binds
+    fun bindsDeleteEventWithIdRemoteUseCaseImp(deleteEventWithIdRemoteUseCaseImp: DeleteEventWithIdRemoteUseCaseImp): DeleteEventWithIdRemoteUseCase
 
     companion object {
         private const val SECRET_SHARED_PREFERENCES = "secret_shared_preferences"

--- a/data/src/main/java/me/androidbox/data/local/event/EventRepositoryImp.kt
+++ b/data/src/main/java/me/androidbox/data/local/event/EventRepositoryImp.kt
@@ -73,6 +73,7 @@ class EventRepositoryImp @Inject constructor(
         val result = checkResult {
             eventDao.deleteEventById(id)
             eventDao.insertSyncEvent(EventSyncEntity(id, SyncAgendaType.DELETE))
+
         }
 
         val responseState = result.fold(

--- a/data/src/main/java/me/androidbox/data/local/event/EventRepositoryImp.kt
+++ b/data/src/main/java/me/androidbox/data/local/event/EventRepositoryImp.kt
@@ -73,7 +73,6 @@ class EventRepositoryImp @Inject constructor(
         val result = checkResult {
             eventDao.deleteEventById(id)
             eventDao.insertSyncEvent(EventSyncEntity(id, SyncAgendaType.DELETE))
-
         }
 
         val responseState = result.fold(

--- a/data/src/main/java/me/androidbox/data/local/event/EventRepositoryImp.kt
+++ b/data/src/main/java/me/androidbox/data/local/event/EventRepositoryImp.kt
@@ -72,7 +72,23 @@ class EventRepositoryImp @Inject constructor(
     override suspend fun deleteEventById(id: String): ResponseState<Unit> {
         val result = checkResult {
             eventDao.deleteEventById(id)
-            eventDao.insertSyncEvent(EventSyncEntity(id, SyncAgendaType.DELETE))
+        }
+
+        val responseState = result.fold(
+            onSuccess = {
+                ResponseState.Success(Unit)
+            },
+            onFailure = { throwable ->
+                ResponseState.Failure(throwable)
+            }
+        )
+
+        return responseState
+    }
+
+    override suspend fun insertSyncEvent(eventId: String, syncAgendaType: SyncAgendaType): ResponseState<Unit> {
+        val result = checkResult {
+            eventDao.insertSyncEvent(EventSyncEntity(eventId, SyncAgendaType.DELETE))
         }
 
         val responseState = result.fold(

--- a/data/src/main/java/me/androidbox/data/remote/event/DeleteEventWithIdRemoteUseCaseImp.kt
+++ b/data/src/main/java/me/androidbox/data/remote/event/DeleteEventWithIdRemoteUseCaseImp.kt
@@ -1,0 +1,27 @@
+package me.androidbox.data.remote.event
+
+import me.androidbox.data.remote.network.event.EventService
+import me.androidbox.data.remote.util.CheckResult.checkResult
+import me.androidbox.domain.authentication.ResponseState
+import me.androidbox.domain.event.usecase.DeleteEventWithIdRemoteUseCase
+import javax.inject.Inject
+
+class DeleteEventWithIdRemoteUseCaseImp @Inject constructor(
+    private val eventService: EventService
+) : DeleteEventWithIdRemoteUseCase {
+
+    override suspend fun execute(eventId: String): ResponseState<Unit> {
+        val result = checkResult {
+            eventService.deleteEventWithId(eventId)
+        }
+
+        return result.fold(
+            onSuccess = {
+                ResponseState.Success(Unit)
+            },
+            onFailure = { throwable ->
+                ResponseState.Failure(throwable)
+            }
+        )
+    }
+}

--- a/data/src/main/java/me/androidbox/data/remote/network/event/EventService.kt
+++ b/data/src/main/java/me/androidbox/data/remote/network/event/EventService.kt
@@ -16,12 +16,12 @@ interface EventService {
 
     @GET(EndPointConstant.EVENT)
     suspend fun getEventWithId(
-        @Query("id") eventId: String
+        @Query("eventId") eventId: String
     ): EventDto
 
     @DELETE(EndPointConstant.EVENT)
     suspend fun deleteEventWithId(
-        @Query("id") eventId: String
+        @Query("eventId") eventId: String
     )
 
     @Multipart

--- a/domain/src/main/java/me/androidbox/domain/authentication/remote/EventRepository.kt
+++ b/domain/src/main/java/me/androidbox/domain/authentication/remote/EventRepository.kt
@@ -3,6 +3,7 @@ package me.androidbox.domain.authentication.remote
 import kotlinx.coroutines.flow.Flow
 import me.androidbox.domain.authentication.ResponseState
 import me.androidbox.domain.agenda.model.Event
+import me.androidbox.domain.constant.SyncAgendaType
 
 interface EventRepository {
     fun getEventsFromTimeStamp(startTimeStamp: Long, endTimeStamp: Long): Flow<ResponseState<List<Event>>>
@@ -12,4 +13,6 @@ interface EventRepository {
     suspend fun deleteEventById(id: String): ResponseState<Unit>
 
     fun getEventById(id: String): Flow<ResponseState<Event>>
+
+    suspend fun insertSyncEvent(eventId: String, syncAgendaType: SyncAgendaType): ResponseState<Unit>
 }

--- a/domain/src/main/java/me/androidbox/domain/event/usecase/DeleteEventWithIdRemoteUseCase.kt
+++ b/domain/src/main/java/me/androidbox/domain/event/usecase/DeleteEventWithIdRemoteUseCase.kt
@@ -1,0 +1,7 @@
+package me.androidbox.domain.event.usecase
+
+import me.androidbox.domain.authentication.ResponseState
+
+interface DeleteEventWithIdRemoteUseCase {
+    suspend fun execute(eventId: String): ResponseState<Unit>
+}

--- a/presentation/src/main/java/me/androidbox/presentation/agenda/viewmodel/AgendaViewModel.kt
+++ b/presentation/src/main/java/me/androidbox/presentation/agenda/viewmodel/AgendaViewModel.kt
@@ -16,6 +16,7 @@ import me.androidbox.domain.authentication.preference.PreferenceRepository
 import me.androidbox.domain.authentication.remote.AgendaLocalRepository
 import me.androidbox.domain.authentication.remote.EventRepository
 import me.androidbox.domain.authentication.usecase.LogoutUseCase
+import me.androidbox.domain.event.usecase.DeleteEventWithIdRemoteUseCase
 import me.androidbox.domain.work_manager.AgendaSynchronizer
 import me.androidbox.domain.work_manager.FullAgendaSynchronizer
 import me.androidbox.presentation.agenda.screen.AgendaScreenEvent
@@ -30,6 +31,7 @@ class AgendaViewModel @Inject constructor(
     private val usersInitialsExtractionUseCase: UsersInitialsExtractionUseCase,
     private val eventRepository: EventRepository,
     private val logoutUseCase: LogoutUseCase,
+    private val deleteEventWithIdRemoteUseCase: DeleteEventWithIdRemoteUseCase,
     private val agendaLocalRepository: AgendaLocalRepository,
     private val agendaSynchronizer: AgendaSynchronizer,
     private val fullAgendaSynchronizer: FullAgendaSynchronizer
@@ -93,6 +95,8 @@ class AgendaViewModel @Inject constructor(
     fun deleteEventById(eventId: String) {
         viewModelScope.launch {
             eventRepository.deleteEventById(eventId)
+            deleteEventWithIdRemoteUseCase.execute(eventId)
+            fetchAgendaItems(agendaScreenState.value.selectedDate)
         }
     }
 

--- a/presentation/src/main/java/me/androidbox/presentation/event/viewmodel/EventViewModel.kt
+++ b/presentation/src/main/java/me/androidbox/presentation/event/viewmodel/EventViewModel.kt
@@ -21,6 +21,7 @@ import me.androidbox.domain.alarm_manager.toAlarmItem
 import me.androidbox.domain.authentication.ResponseState
 import me.androidbox.domain.authentication.preference.PreferenceRepository
 import me.androidbox.domain.authentication.remote.EventRepository
+import me.androidbox.domain.event.usecase.DeleteEventWithIdRemoteUseCase
 import me.androidbox.domain.event.usecase.VerifyVisitorEmailUseCase
 import me.androidbox.domain.work_manager.UploadEvent
 import me.androidbox.presentation.alarm_manager.AlarmReminderProvider
@@ -36,6 +37,7 @@ class EventViewModel @Inject constructor(
     private val eventRepository: EventRepository,
     private val usersInitialsExtractionUseCase: UsersInitialsExtractionUseCase,
     private val verifyVisitorEmailUseCase: VerifyVisitorEmailUseCase,
+    private val deleteEventWithIdRemoteUseCase: DeleteEventWithIdRemoteUseCase,
     private val preferenceRepository: PreferenceRepository,
     private val alarmScheduler: AlarmScheduler,
     private val uploadEvent: UploadEvent,
@@ -327,6 +329,7 @@ class EventViewModel @Inject constructor(
     private fun deleteEvent(eventId: String) {
         viewModelScope.launch {
             eventRepository.deleteEventById(eventId)
+            deleteEventWithIdRemoteUseCase.execute(eventId)
         }
     }
 }

--- a/presentation/src/main/java/me/androidbox/presentation/event/viewmodel/EventViewModel.kt
+++ b/presentation/src/main/java/me/androidbox/presentation/event/viewmodel/EventViewModel.kt
@@ -21,6 +21,7 @@ import me.androidbox.domain.alarm_manager.toAlarmItem
 import me.androidbox.domain.authentication.ResponseState
 import me.androidbox.domain.authentication.preference.PreferenceRepository
 import me.androidbox.domain.authentication.remote.EventRepository
+import me.androidbox.domain.constant.SyncAgendaType
 import me.androidbox.domain.event.usecase.DeleteEventWithIdRemoteUseCase
 import me.androidbox.domain.event.usecase.VerifyVisitorEmailUseCase
 import me.androidbox.domain.work_manager.UploadEvent
@@ -329,7 +330,14 @@ class EventViewModel @Inject constructor(
     private fun deleteEvent(eventId: String) {
         viewModelScope.launch {
             eventRepository.deleteEventById(eventId)
-            deleteEventWithIdRemoteUseCase.execute(eventId)
+
+            when(deleteEventWithIdRemoteUseCase.execute(eventId)) {
+                ResponseState.Loading -> Unit /* TODO Show loading */
+                is ResponseState.Success -> Unit /* Nothing to do here as the event from API was success */
+                is ResponseState.Failure -> {
+                    eventRepository.insertSyncEvent(eventId, SyncAgendaType.DELETE)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Pull Request template

###  What does this PR solve?

Deleting events using the /event?eventId endpoint

Offline mode
1) Delete from the room DB
2) Insert the event ID into the syncTable 
3) Fetch from DB (Will contain fetched items that were inserted from the EP)
4) When back online run sync worker /synAgenda

Online mode
1) Delete from the room DB
2) Delete from the /event EP
3) Fetch from DB with events inserted from EP

The only difference is inserting to the sync table when offline, to be sync'ed when online again.

**NOTE: I haven't completed checking for network connection**

### Additional information (optional)
