### PR TITLE
[57] Display in edit or non-editable mode

### DIFF
--- a/component/src/main/java/me/androidbox/component/agenda/AlarmReminder.kt
+++ b/component/src/main/java/me/androidbox/component/agenda/AlarmReminder.kt
@@ -3,14 +3,21 @@ package me.androidbox.component.agenda
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -19,12 +26,12 @@ import me.androidbox.component.R
 import me.androidbox.component.ui.theme.BusbyTaskyTheme
 import me.androidbox.component.ui.theme.agendaBodyTextColor
 import me.androidbox.component.ui.theme.backgroundWhiteColor
-import java.time.ZonedDateTime
 
 @Composable
 fun AlarmReminder(
     reminderText: String,
     onReminderClicked: () -> Unit,
+    isEditMode: Boolean,
     modifier: Modifier = Modifier) {
 
         Row(modifier = modifier.clickable {
@@ -44,8 +51,20 @@ fun AlarmReminder(
                     color = MaterialTheme.colorScheme.agendaBodyTextColor)
             }
 
-            Row {
-                Icon(painter = painterResource(id = R.drawable.forward_arrow), contentDescription = "forward arrow")
+            if(isEditMode) {
+                Row {
+                    if(isEditMode) {
+                        IconButton(onClick = {
+                            onReminderClicked()
+                        }) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.forward_arrow),
+                                contentDescription = stringResource(R.string.forward_arrow),
+                                tint = Color.Black
+                            )
+                        }
+                    }
+                }
             }
         }
 }
@@ -64,6 +83,7 @@ fun PreviewAlarmReminder() {
     BusbyTaskyTheme {
         AlarmReminder(
             reminderText = "30 minutes before",
+            isEditMode = true,
             modifier = Modifier
                 .fillMaxWidth()
                 .background(color = MaterialTheme.colorScheme.backgroundWhiteColor),

--- a/component/src/main/java/me/androidbox/component/agenda/AlarmReminder.kt
+++ b/component/src/main/java/me/androidbox/component/agenda/AlarmReminder.kt
@@ -34,39 +34,37 @@ fun AlarmReminder(
     isEditMode: Boolean,
     modifier: Modifier = Modifier) {
 
-        Row(modifier = modifier.clickable {
-            onReminderClicked()
-        },
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween) {
+    Row(modifier = modifier.clickable {
+        onReminderClicked()
+    },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween) {
+        Row {
+            Icon(painter = painterResource(id = R.drawable.bell), contentDescription = "bell")
+
+            Spacer(modifier = Modifier.width(20.dp))
+
+            Text(
+                text = reminderText,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+                color = MaterialTheme.colorScheme.agendaBodyTextColor)
+        }
+
+        if(isEditMode) {
             Row {
-                Icon(painter = painterResource(id = R.drawable.bell), contentDescription = "bell")
-
-                Spacer(modifier = Modifier.width(20.dp))
-
-                Text(
-                    text = reminderText,
-                    fontWeight = FontWeight.Normal,
-                    fontSize = 16.sp,
-                    color = MaterialTheme.colorScheme.agendaBodyTextColor)
-            }
-
-            if(isEditMode) {
-                Row {
-                    if(isEditMode) {
-                        IconButton(onClick = {
-                            onReminderClicked()
-                        }) {
-                            Icon(
-                                painter = painterResource(id = R.drawable.forward_arrow),
-                                contentDescription = stringResource(R.string.forward_arrow),
-                                tint = Color.Black
-                            )
-                        }
-                    }
+                IconButton(onClick = {
+                    onReminderClicked()
+                }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.forward_arrow),
+                        contentDescription = stringResource(R.string.forward_arrow),
+                        tint = Color.Black
+                    )
                 }
             }
         }
+    }
 }
 
 enum class AlarmReminderItem(@StringRes val stringResId: Int) {

--- a/domain/src/main/java/me/androidbox/domain/DateTimeFormatterProvider.kt
+++ b/domain/src/main/java/me/androidbox/domain/DateTimeFormatterProvider.kt
@@ -15,6 +15,7 @@ object DateTimeFormatterProvider {
 
     const val DATE_PATTERN = "MMM, dd yyyy"
     const val TIME_PATTERN = "HH:mm"
+    const val LONG_DATE_PATTERN = "d MMMM yyyy"
 
     fun ZonedDateTime.formatDateTime(pattern: String): String {
         return DateTimeFormatter.ofPattern(pattern, Locale.getDefault()).format(this)

--- a/presentation/src/main/java/me/androidbox/presentation/event/screen/EventScreen.kt
+++ b/presentation/src/main/java/me/androidbox/presentation/event/screen/EventScreen.kt
@@ -53,11 +53,11 @@ fun EventScreen(
                     .fillMaxWidth()
                     .background(color = MaterialTheme.colorScheme.backgroundBackColor)
                     .padding(horizontal = 16.dp),
-                editModeType = EditModeType.SaveMode(),
+                editModeType = if(eventScreenState.isEditMode) { EditModeType.SaveMode() } else { EditModeType.EditMode() },
                 displayDate = "31 March 2023", /* TODO Get the date from the agenda screen that was selected by the user */
                 onCloseClicked = onCloseClicked,
                 onEditClicked = {
-
+                    eventScreenEvent(EventScreenEvent.OnEditModeChangeStatus(isEditModel = true))
                 },
                 onSaveClicked = {
                     eventScreenEvent(EventScreenEvent.OnSaveEventDetails)
@@ -84,7 +84,7 @@ fun EventScreen(
                         agendaHeaderItem = AgendaHeaderItem.EVENT,
                         subTitle = eventScreenState.eventTitle,
                         description = eventScreenState.eventDescription,
-                        isEditMode = true,
+                        isEditMode = eventScreenState.isEditMode,
                         onEditTitleClicked = { newTitle ->
                             onEditTitleClicked(newTitle)
                         },
@@ -102,7 +102,7 @@ fun EventScreen(
 
                     Spacer(modifier = modifier.height(26.dp))
                     AgendaDuration(
-                        isEditMode = true,
+                        isEditMode = eventScreenState.isEditMode,
                         startTime = eventScreenState.startTime.formatDateTime(TIME_PATTERN),
                         endTime = eventScreenState.endTime.formatDateTime(TIME_PATTERN),
                         startDate = eventScreenState.startDate.formatDateTime(DATE_PATTERN),
@@ -142,6 +142,7 @@ fun EventScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .background(color = MaterialTheme.colorScheme.backgroundWhiteColor),
+                        isEditMode = eventScreenState.isEditMode,
                         onReminderClicked = {
                             eventScreenEvent(EventScreenEvent.OnShowAlarmReminderDropdown(shouldOpen = true))
                         }
@@ -242,10 +243,29 @@ fun EventScreen(
 
 @Composable
 @Preview(showBackground = true)
-fun PreviewEventScreen() {
+fun PreviewEventScreenEditMode() {
     BusbyTaskyTheme {
         EventScreen(
-            eventScreenState = EventScreenState(),
+            eventScreenState = EventScreenState(
+                isEditMode = false
+            ),
+            eventScreenEvent = {},
+            modifier = Modifier.fillMaxWidth(),
+            onEditDescriptionClicked = {},
+            onEditTitleClicked = {},
+            onCloseClicked = {}
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun PreviewEventScreenSaveMode() {
+    BusbyTaskyTheme {
+        EventScreen(
+            eventScreenState = EventScreenState(
+                isEditMode = true
+            ),
             eventScreenEvent = {},
             modifier = Modifier.fillMaxWidth(),
             onEditDescriptionClicked = {},

--- a/presentation/src/main/java/me/androidbox/presentation/event/screen/EventScreen.kt
+++ b/presentation/src/main/java/me/androidbox/presentation/event/screen/EventScreen.kt
@@ -27,6 +27,7 @@ import me.androidbox.component.ui.theme.backgroundBackColor
 import me.androidbox.component.ui.theme.backgroundWhiteColor
 import me.androidbox.component.ui.theme.dropDownMenuBackgroundColor
 import me.androidbox.domain.DateTimeFormatterProvider.DATE_PATTERN
+import me.androidbox.domain.DateTimeFormatterProvider.LONG_DATE_PATTERN
 import me.androidbox.domain.DateTimeFormatterProvider.TIME_PATTERN
 import me.androidbox.domain.DateTimeFormatterProvider.formatDateTime
 import java.time.ZoneId
@@ -54,7 +55,7 @@ fun EventScreen(
                     .background(color = MaterialTheme.colorScheme.backgroundBackColor)
                     .padding(horizontal = 16.dp),
                 editModeType = if(eventScreenState.isEditMode) { EditModeType.SaveMode() } else { EditModeType.EditMode() },
-                displayDate = "31 March 2023", /* TODO Get the date from the agenda screen that was selected by the user */
+                displayDate = eventScreenState.startDate.formatDateTime(LONG_DATE_PATTERN),
                 onCloseClicked = onCloseClicked,
                 onEditClicked = {
                     eventScreenEvent(EventScreenEvent.OnEditModeChangeStatus(isEditModel = true))

--- a/presentation/src/main/java/me/androidbox/presentation/event/screen/EventScreenEvent.kt
+++ b/presentation/src/main/java/me/androidbox/presentation/event/screen/EventScreenEvent.kt
@@ -28,4 +28,5 @@ sealed interface EventScreenEvent {
     data class OnAttendeeAdded(val attendee: Attendee): EventScreenEvent
     data class OnShowDeleteEventAlertDialog(val shouldShowDeleteAlertDialog: Boolean): EventScreenEvent
     data class OnDeleteEvent(val eventId: String): EventScreenEvent
+    data class OnEditModeChangeStatus(val isEditModel: Boolean): EventScreenEvent
 }

--- a/presentation/src/main/java/me/androidbox/presentation/event/viewmodel/EventViewModel.kt
+++ b/presentation/src/main/java/me/androidbox/presentation/event/viewmodel/EventViewModel.kt
@@ -75,7 +75,7 @@ class EventViewModel @Inject constructor(
                 else -> {
                     _eventScreenState.update { eventScreenState ->
                         eventScreenState.copy(
-                            isEditMode = false,
+                            isEditMode = true,
                             eventId = UUID.randomUUID().toString()
                         )
                     }
@@ -210,6 +210,14 @@ class EventViewModel @Inject constructor(
             is EventScreenEvent.OnDeleteEvent -> {
                 deleteEvent(eventScreenEvent.eventId)
             }
+
+            is EventScreenEvent.OnEditModeChangeStatus -> {
+                _eventScreenState.update { eventScreenState ->
+                    eventScreenState.copy(
+                        isEditMode = eventScreenEvent.isEditModel
+                    )
+                }
+            }
         }
     }
 
@@ -313,7 +321,7 @@ class EventViewModel @Inject constructor(
                 is ResponseState.Success -> {
                     val alarmItem = event.toAlarmItem(AgendaType.EVENT)
                     alarmScheduler.scheduleAlarmReminder(alarmItem)
-                    uploadEvent.upload(event, isEditMode = false)
+                    uploadEvent.upload(event, isEditMode = eventScreenState.value.isEditMode)
 
                     _eventScreenState.update { eventScreenState ->
                         eventScreenState.copy(isSaved = true)

--- a/presentation/src/main/java/me/androidbox/presentation/event/viewmodel/EventViewModel.kt
+++ b/presentation/src/main/java/me/androidbox/presentation/event/viewmodel/EventViewModel.kt
@@ -75,7 +75,7 @@ class EventViewModel @Inject constructor(
                 else -> {
                     _eventScreenState.update { eventScreenState ->
                         eventScreenState.copy(
-                            isEditMode = true,
+                            isEditMode = false,
                             eventId = UUID.randomUUID().toString()
                         )
                     }

--- a/presentation/src/main/java/me/androidbox/presentation/navigation/NavigationGraph.kt
+++ b/presentation/src/main/java/me/androidbox/presentation/navigation/NavigationGraph.kt
@@ -117,11 +117,10 @@ fun NavigationGraph(
                     AgendaType.EVENT -> {
                         when(agendaMenuActionType) {
                             AgendaMenuActionType.OPEN -> {
-                                val open = AgendaMenuActionType.OPEN.name
                                 navHostController.navigate(route = "${Screen.EventScreen.EVENT_SCREEN}/$eventId/${AgendaMenuActionType.OPEN}")
                             }
                             AgendaMenuActionType.EDIT -> {
-                                navHostController.navigate(Screen.EventScreen.route)
+                                navHostController.navigate(route = "${Screen.EventScreen.EVENT_SCREEN}/$eventId/${AgendaMenuActionType.EDIT}")
                             }
                             AgendaMenuActionType.DELETE -> {
                                 agendaViewModel.deleteEventById(eventId)


### PR DESCRIPTION
# Pull Request template

###  What does this PR solve?

- Displays edit arrows when in edit mode
- Tapping the pencil puts the event into edit mode
- Changes the status of the edit mode by showing the arrows

![editmode](https://user-images.githubusercontent.com/14260802/235425174-172bfe4c-1d03-4a97-af9c-32236dfa7562.png)

![non-edit-mode](https://user-images.githubusercontent.com/14260802/235425196-8c979d16-63c2-4f83-802b-f4a3a3f1f63e.png)


### Additional information (optional)
